### PR TITLE
Fix deprecation as suggested by atom

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -1,54 +1,54 @@
 @import "syntax-variables";
 
-.editor {
+:host, atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 }
 
-.editor .gutter {
+:host, atom-text-editor .gutter {
   background-color: @syntax-gutter-background-color;
   color: @syntax-gutter-text-color;
 }
 
-.editor .gutter .line-number.cursor-line {
+:host, atom-text-editor .gutter .line-number.cursor-line {
   background-color: @syntax-gutter-background-color-selected;
   color: @syntax-gutter-text-color-selected;
 }
 
-.editor .gutter .line-number.cursor-line-no-selection {
+:host, atom-text-editor .gutter .line-number.cursor-line-no-selection {
   color: @syntax-gutter-text-color-selected;
 }
 
-.editor .wrap-guide {
+:host, atom-text-editor .wrap-guide {
   color: @syntax-wrap-guide-color;
 }
 
-.editor .indent-guide {
+:host, atom-text-editor .indent-guide {
   color: @syntax-indent-guide-color;
 }
 
-.editor .invisible-character {
+:host, atom-text-editor .invisible-character {
   color: @syntax-invisible-character-color;
 }
 
-.editor .search-results .marker .region {
+:host, atom-text-editor .search-results .marker .region {
   background-color: transparent;
   border: @syntax-result-marker-color;
 }
 
-.editor .search-results .marker.current-result .region {
+:host, atom-text-editor .search-results .marker.current-result .region {
   border: @syntax-result-marker-color-selected;
 }
 
-.editor.is-focused .cursor {
+:host, atom-text-editor.is-focused .cursor {
   border-color: @syntax-cursor-color;
 }
 
-.editor.is-focused .selection .region {
+:host, atom-text-editor.is-focused .selection .region {
   background-color: @syntax-selection-color;
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+:host, atom-text-editor.is-focused .line-number.cursor-line-no-selection, :host, atom-text-editor.is-focused .line.cursor-line {
   background-color: rgba(0, 0, 0, 0.07);
 }
 


### PR DESCRIPTION
As suggested by the deprecation cop in atom, I have changed all `.editor` class selector to `:host, atom-text-editor`. I have tried the `.atom-text-editor` only, but it doesn't work.
